### PR TITLE
Update tree alias

### DIFF
--- a/config/aliases.sh
+++ b/config/aliases.sh
@@ -131,7 +131,7 @@ alias lu='ls -ltur'       # sort by and show access time, most recent last
 alias lt='ls -ltr'        # sort by date, most recent last
 alias lm='ls -al |more'   # pipe through 'more'
 alias lr='ls -lR'         # recursive ls
-alias tree='tree -Csu'    # nice alternative to 'recursive ls'
+alias tree='tree -C'   	  # nice alternative to 'recursive ls'
 
 #-------------------------------------------------------------
 # ffmpeg


### PR DESCRIPTION
Drop the `-s` and `-u` args from the tree alias which print the size of the files in bytes and the username for the file respectively