### PR TITLE
Remove -p arg to split_window for version 3.4

### DIFF
--- a/config/tmux.conf
+++ b/config/tmux.conf
@@ -34,8 +34,8 @@ bind l select-pane -R
 bind-key ^D detach-client
 
 # Create splits and vertical splits
-bind-key | split-window -h -p 50 -c "#{pane_current_path}"
-bind-key - split-window -p 50 -c "#{pane_current_path}"
+bind-key | split-window -h -c "#{pane_current_path}"
+bind-key - split-window -c "#{pane_current_path}"
 
 # Pane resize in all four directions using vi bindings.
 # Can use these raw but I map them to shift-ctrl-<h,j,k,l> in iTerm.


### PR DESCRIPTION
Tmux version 3.4 removes the `-p` arg from `split-window`.

The fix here is simply to remove this arg (controls the percentage). It probably wasn't being used since `-p 50` corresponds to a simple split