### PR TITLE
Automatic yes to apt-get install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,8 +47,8 @@ esac
 # Installing on linux with apt
 if [ $machine == "Linux" ]; then
     DOT_DIR=$(dirname $(realpath $0))
-    [ $zsh == true ] && sudo apt-get install zsh
-    [ $tmux == true ] && sudo apt-get install tmux 
+    [ $zsh == true ] && sudo apt-get install -y zsh
+    [ $tmux == true ] && sudo apt-get install -y tmux 
 
 # Installing on mac with homebrew
 elif [ $machine == "Mac" ]; then


### PR DESCRIPTION
We use `apt-get install -y` to skip and requests.

This means we can execute this using the `dotfiles` section of vscode settings.json