### PR TITLE
Fix erroneous change to git aliases

### DIFF
--- a/config/aliases.sh
+++ b/config/aliases.sh
@@ -101,8 +101,8 @@ alias gsta="git stash apply"
 alias gstd="git stash drop"
 alias gstc="git stash clear"
 
-alias ggsup='git branch --set-upstream-to=origin/$(git branch --current)'
-alias gpsup='git push --set-upstream origin $(git branch --current)'
+alias ggsup='git branch --set-upstream-to=origin/$(git branch --show-current)'
+alias gpsup='git push --set-upstream origin $(git branch --show-current)'
 
 #-------------------------------------------------------------
 # tmux


### PR DESCRIPTION
Previously I changed from using `git_current_branch` -> `git branch --current`.

The correct command is `git branch --show-current`.