### PR TITLE
Share ZSH history and remove unused aliases

### DIFF
--- a/config/aliases.sh
+++ b/config/aliases.sh
@@ -101,8 +101,8 @@ alias gsta="git stash apply"
 alias gstd="git stash drop"
 alias gstc="git stash clear"
 
-alias ggsup='git branch --set-upstream-to=origin/$(git branch --current)'
-alias gpsup='git push --set-upstream origin $(git branch --current)'
+alias ggsup='git branch --set-upstream-to=origin/$(git branch --show-current)'
+alias gpsup='git push --set-upstream origin $(git branch --show-current)'
 
 #-------------------------------------------------------------
 # tmux

--- a/config/aliases.sh
+++ b/config/aliases.sh
@@ -3,7 +3,6 @@
 # -------------------------------------------------------------------
 
 alias cdg="cd ~/git"
-alias zrc="cd $DOT_DIR/zsh"
 alias dot="cd $DOT_DIR"
 alias jp="jupyter lab"
 alias vm="ssh danc@danc.dev-vms.speechmatics.io"
@@ -15,7 +14,6 @@ alias vm="ssh danc@danc.dev-vms.speechmatics.io"
 alias cl="clear"
 
 # file and directories
-alias rmd='rm -rf'
 alias cp='cp -i'
 alias mv='mv -i'
 alias mkdir='mkdir -p'

--- a/config/aliases_speechmatics.sh
+++ b/config/aliases_speechmatics.sh
@@ -3,28 +3,9 @@ HOST_IP_ADDR=$(hostname -I | awk '{ print $1 }') # This gets the actual ip addr
 # Quick navigation add more here
 alias a="cd ~/git/aladdin"
 alias cde="cd /exp/$(whoami)"
-alias cdt="cd ~/tb"
-alias cdn="cd ~/notebooks"
-
-# Perish machines
-alias p1="cd /perish_aml01"
-alias p2="cd /perish_aml02"
-alias p3="cd /perish_aml03"
-alias p4="cd /perish_aml04"
-alias p5="cd /perish_aml05"
-alias g1="cd /perish_g01"
-alias g2="cd /perish_g02"
-alias g3="cd /perish_g03"
-
-alias b1="ssh b1"
-alias b2="ssh b2"
-alias b3="ssh b3"
-alias b4="ssh b4"
-alias b5="ssh b5"
 
 # Change to aladdin directory and activate SIF
 alias msa="make -C /home/$(whoami)/git/aladdin/ shell"
-alias msa2="make -C /home/$(whoami)/git/aladdin2/ shell"
 
 # Activate aladdin SIF in current directory
 alias msad="/home/$(whoami)/git/aladdin/env/singularity.sh -c "$SHELL""
@@ -78,6 +59,7 @@ tblink () {
   echo "logdir: $logdir"
   singularity exec "$TENSOR_BOARD_SIF" tensorboard --host=$HOST_IP_ADDR --reload_multifile true --logdir=$logdir
 }
+
 tbadd() {
   # Add experiment folder to existing tensorboard directory (see tblink)
   # example: `tbadd ./lm/20210825 25` will symlink ./lm/20210824 to ~/tb/25
@@ -128,21 +110,26 @@ qlogin () {
     echo "Usage: qlogin <num_slots> cpu" >&2
   fi
 }
+
 qtail () {
-  tail -f $(qlog $@)
+  tail -f $(qlog "$@")
 }
+
 qlast () {
   # Tail the last running job
   job_id=$(qstat | awk '$5=="r" {print $1}' | grep -E '[0-9]' | sort -r | head -n 1)
   echo "qtail of most recent job ${job_id}"
   qtail ${job_id} 
 }
+
 qless () {
-  less $(qlog $@)
+  less $(qlog "$@")
 }
+
 qcat () {
-  cat $(qlog $@)
+  cat $(qlog "$@")
 }
+
 qlog () {
   # Get log path of job
   if [ "$#" -eq 1 ]; then
@@ -177,11 +164,11 @@ qdesc () {
 }
 
 qrecycle () {
-    [ ! -z $SINGULARITY_CONTAINER ] && ssh localhost "qrecycle $@" || command qrecycle "$@";
+    [ -n  "$SINGULARITY_CONTAINER" ] && ssh localhost "qrecycle"  "$@" || command qrecycle "$@";
 }
 
 qupdate () {
-    [ ! -z $SINGULARITY_CONTAINER ] && ssh localhost "qupdate"|| command qupdate ;
+    [ -n "$SINGULARITY_CONTAINER" ] && ssh localhost "qupdate"|| command qupdate ;
 }
 
 # Only way to get a gpu is via queue. WARNING: this will hide GPUs if working locally

--- a/config/extras.sh
+++ b/config/extras.sh
@@ -2,24 +2,50 @@
 # zsh extra settings
 #-------------------------------------------------------------
 
+# Safety: Force confirmation when using rm with wildcards
 setopt RM_STAR_WAIT              # Wait when typing `rm *` before being able to confirm
+
+# Terminal behavior
 setopt NO_BEEP                   # Don't beep on errors in ZLE
+
+# History handling and cleaning
 setopt HIST_REDUCE_BLANKS        # Remove superfluous blanks before recording entry.
 setopt HIST_IGNORE_SPACE         # Don't record an entry starting with a space.
-setopt HIST_NO_STORE             # Remove the history (fc -l) command from the history.
+setopt HIST_NO_STORE            # Remove the history (fc -l) command from the history.
 setopt EXTENDED_HISTORY          # Write the history file in the ":start:elapsed;command" format.
 setopt HIST_SAVE_NO_DUPS         # Don't write duplicate entries in the history file.
 setopt HIST_EXPIRE_DUPS_FIRST    # Expire duplicate entries first when trimming history.
 setopt HIST_FIND_NO_DUPS         # Do not display a line previously found.
-setopt completealiases
-setopt always_to_end
-setopt list_ambiguous
-setopt inc_append_history
-export HISTSIZE=100000 # big big history
-export HISTFILESIZE=100000 # big big history
-unsetopt hup
-unsetopt list_beep
+
+# Completion behavior
+setopt completealiases           # Expand aliases before completion
+setopt always_to_end             # Move cursor to end of word after completion
+setopt list_ambiguous           # Show completion menu when ambiguous
+setopt share_history            # Share history between all sessions
+
+# History size configuration
+export SAVEHIST=100000
+export HISTSIZE=100000          # Number of commands stored in memory
+export HISTFILESIZE=100000      # Number of commands stored in history file
+
+# Process handling
+unsetopt hup                    # Don't kill background jobs when shell exits
+
+# Terminal behavior
+unsetopt list_beep             # Don't beep when displaying completion list
+
+# Disable hostname completion
 zstyle ':completion:*' hosts off
+
+# Ensure HISTFILE is set
+if [[ -z "$HISTFILE" ]]; then
+    export HISTFILE="${HOME}/.histfile"
+fi
+
+# Create the history file if it doesn't exist
+if [[ ! -f "$HISTFILE" ]]; then
+    touch "$HISTFILE"
+fi
 
 # Set Up and Down arrow keys to the (zsh-)history-substring-search plugin
 # `-n` means `not empty`, equivalent to `! -z`

--- a/config/extras.sh
+++ b/config/extras.sh
@@ -14,11 +14,11 @@ setopt HIST_FIND_NO_DUPS         # Do not display a line previously found.
 setopt completealiases
 setopt always_to_end
 setopt list_ambiguous
+setopt inc_append_history
 export HISTSIZE=100000 # big big history
 export HISTFILESIZE=100000 # big big history
 unsetopt hup
 unsetopt list_beep
-skip_global_compinit=1
 zstyle ':completion:*' hosts off
 
 # Set Up and Down arrow keys to the (zsh-)history-substring-search plugin

--- a/config/zshrc.sh
+++ b/config/zshrc.sh
@@ -1,5 +1,4 @@
 CONFIG_DIR=$(dirname $(realpath ${(%):-%x}))
-DOT_DIR=$CONFIG_DIR/../
 
 source ~/.zsh/powerlevel10k/powerlevel10k.zsh-theme
 source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 USAGE=$(cat <<-END
-    Usage: ./deploy.sh [OPTIONS], eg. ./deploy.sh --local --vim
+    Usage: ./deploy.sh [OPTIONS], eg. ./deploy.sh --local
     Creates ~/.zshrc and ~/.tmux.conf with location
     specific config
 
     OPTIONS:
         --local                 deploy local config only, only common aliases are sourced
-        --vim                   deploy very simple vimrc config
 END
 )
 
 export DOT_DIR=$(dirname $(realpath $0))
 
 LOC="remote"
-VIM="false"
 while (( "$#" )); do
     case "$1" in
         -h|--help)

--- a/install.sh
+++ b/install.sh
@@ -46,14 +46,12 @@ esac
 
 # Installing on linux with apt
 if [ $machine == "Linux" ]; then
-    DOT_DIR=$(dirname $(realpath $0))
     [ $zsh == true ] && sudo apt-get install -y zsh
     [ $tmux == true ] && sudo apt-get install -y tmux 
 
 # Installing on mac with homebrew
 elif [ $machine == "Mac" ]; then
     brew install coreutils  # Mac won't have realpath before coreutils installed
-    DOT_DIR=$(dirname $(realpath $0))
     [ $zsh == true ] && brew install zsh
     [ $tmux == true ] && brew install tmux
 fi


### PR DESCRIPTION
This MR adds an explicit HISTFILE if it does not exist already and uses the `share_history` opt to write and read to this file with different ZSH processes.

It also removes old and unused aliases.