### PR TITLE
Ignore karabiner and iterm2 from .config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # ignore files
-packer_compiled.lua
-nvim/nvim
+iterm2
+karabiner
 neofetch
+nvim/nvim
+packer_compiled.lua


### PR DESCRIPTION
Does what it says on the tin.

Arguably a bad name for a repository.