### PR TITLE
Require SSH_CONNECTION env var set before setting CUDA_VISIBLE_DEVICES

### DIFF
--- a/config/aliases_speechmatics.sh
+++ b/config/aliases_speechmatics.sh
@@ -171,8 +171,8 @@ qupdate () {
     [ -n "$SINGULARITY_CONTAINER" ] && ssh localhost "qupdate"|| command qupdate ;
 }
 
-# Only way to get a gpu is via queue. WARNING: this will hide GPUs if working locally
-if [ -z $CUDA_VISIBLE_DEVICES ]; then
+# Hide GPUs for bare SSH sessions — GPU access must go via the queue
+if [ -n "$SSH_CONNECTION" ] && [ -z "$JOB_ID" ] && [ -z "$CUDA_VISIBLE_DEVICES" ]; then
   export CUDA_VISIBLE_DEVICES=
 fi
 


### PR DESCRIPTION
When running `./deploy.sh` without the `--local` flag, we'll source the speechmatics config in `aliases_speechmatics.sh`.

This will set the `CUDA_VISIBLE_DEVICES` env var to an empty string if it's not already set. This has caused some pain in the past, making GPUs on local machines 'invisible'. The intention is to force users to schedule a job in order to get a GPU.

This PR changes adds a guard that we must have both an active `SSH_CONNECTION` and an unset `JOB_ID`, in addition to an unset `CUDA_VISIBLE_DEVICES`.